### PR TITLE
Sequence rhythmic subdivisions using recursive lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/workspace.xml
 testfile.wav
+*.pyc

--- a/repl.py
+++ b/repl.py
@@ -3,6 +3,7 @@ from sequencer import Sequencer
 
 import code
 import os
+import Queue
 
 from threading import Thread
 

--- a/repl.py
+++ b/repl.py
@@ -1,69 +1,25 @@
-from pyaudio import paInt16
-
-from packages.soundmodular import Patcher
 from noteparser import get_raag, get_raag_list
-from util.freq import get_frequency
+from sequencer import Sequencer
 
 import code
 import os
 
 from threading import Thread
-import Queue
-
-options = {
-    'format': paInt16,
-    'channels': 2,
-    'sampling_rate': 22000,
-    'save_file': 'testfile.wav'
-}
 
 root = [440]
 raag = {'name' : None}
 
-patcher = Patcher(options)
-module = patcher.module
-T = 0.2
-
+sequencer = Sequencer()
 status_queue = Queue.Queue()
 
 status = {
     'notes': [1],
     'root': root,
-    'duration': [T],
+    'duration': [0.2],
     'stutter': [1]
 }
 
-
-def sequence(queue):
-    current_status = {
-        'notes': [1],
-        'root': [440],
-        'duration': [0.2],
-        'stutter': [1]
-    }
-    while True:
-
-        try:
-            new_status = queue.get(timeout=0.1)
-            current_status = dict(current_status, **new_status)
-        except Queue.Empty:
-            pass
-
-        '''
-        TODO: for note, time in zip(current_status['notes'], current_status['time'])
-        '''
-
-        for note in current_status['notes']:
-            if note == 0:
-                continue
-
-            freq = get_frequency(current_status['root'][0], int(note) - 1)
-            for i in range (0, current_status['stutter'][0]):
-                osc = module.osc_tone(current_status['duration'][0] / current_status['stutter'][0], freq)
-                patcher.to_master(osc, 0.5, 0.5)
-
-
-t = Thread(target=sequence, args=(status_queue,))
+t = Thread(target=sequencer.sequence, args=(status_queue,))
 t.daemon = True
 t.start()
 

--- a/sequencer.py
+++ b/sequencer.py
@@ -1,31 +1,49 @@
 __author__ = 'Sumanth Srinivasan'
 
 from pyaudio import paInt16
-
 from packages.soundmodular import Patcher
-from noteparser import get_raag
 from util.freq import get_frequency
+import Queue
 
-options = {
-    'format': paInt16,
-    'channels': 2,
-    'sampling_rate': 22000,
-    'save_file': 'testfile.wav'
-}
+class Sequencer:
+    def __init__(self):
+        options = {
+            'format': paInt16,
+            'channels': 2,
+            'sampling_rate': 22000,
+            'save_file': 'testfile.wav'
+        }
 
-root = [440]
-raag_name = ['Adana']
-raag = get_raag(raag_name[0])
-print raag['aaroha']
+        self.patcher = Patcher(options)
+        self.module = self.patcher.module
 
-patcher = Patcher(options)
-module = patcher.module
-T = 0.3                 # Time in seconds
+    def sequence(self, queue):
+        current_status = {
+            'notes': [1],
+            'root': [440],
+            'duration': [0.2],
+            'stutter': [1]
+        }
 
-for note in raag['aaroha']:
-    # print (type(note))
-    freq = get_frequency(root[0], int(note) - 1)
-    osc = module.osc_tone(T, freq)
-    patcher.to_master(osc, 0.5, 0.5)
+        while True:
 
-patcher.terminate()
+            try:
+                new_status = queue.get(timeout=0.1)
+                current_status = dict(current_status, **new_status)
+            except Queue.Empty:
+                pass
+
+            '''
+            TODO: for note, time in zip(current_status['notes'], current_status['time'])
+            '''
+
+            for note in current_status['notes']:
+                if note == 0:
+                    continue
+
+                freq = get_frequency(current_status['root'][0], int(note) - 1)
+                for i in range (0, current_status['stutter'][0]):
+                    osc = self.module.osc_tone(current_status['duration'][0] / current_status['stutter'][0], freq)
+                    self.patcher.to_master(osc, 0.5, 0.5)
+
+


### PR DESCRIPTION
This change allows you to sequence rhythmic subdivisions using recursive lists
For example:
If `[2,4,6,8]` plays 4 quarter notes, `[[2,6],4,6,8]` will play 2 8th notes followed by 3 quarter notes, adding up to the same measure. 

Additionally, this change allows you to sequence silences/rest notes. This can be done by using `0` instead of a note.