### PR TITLE
Run aaroha/avaroha phrases

### DIFF
--- a/sequencer.py
+++ b/sequencer.py
@@ -49,7 +49,7 @@ class Sequencer:
         for note in notes:
                 # Subdivided notes are in a list
                 if type(note) is list:
-                    self.play(note, duration/len(note), degrade)
+                    self.play(note, duration/len(note))
                     continue
 
                 # if random.random() <= degrade:

--- a/util/freq.py
+++ b/util/freq.py
@@ -20,4 +20,7 @@ def get_frequency(root_freq, semitone):
     if semitone >= 12:
         return 2 * get_frequency(root_freq, semitone - 12)
 
+    if semitone < 0:
+        return 0.5 * get_frequency(root_freq, semitone + 12)
+
     return root_freq * semitones[semitone]


### PR DESCRIPTION
Instead of looping on a command, `aaroha()` and `avaroha()` will now return a 16-note phrase that will play once. After this, the sequencer will return to metronomic beeping.
Essentially implements #17, where default is a single repeating note.
The length of the phrase can be changed from 16 to any number using the `set_phrase_length()` method. `phrase_length` is a global variable. Cannot be changed ad-hoc for each phrase unless you vary the global variable each time.

Both `aaroha()` and `avaroha()` can take the following properties: `subphrases=[integer]` `stutter=[integer]`, `degrade=[float]`
- `subphrases` argument will divide the total phrase (default 16) into unequal subphrases and fill each of them with a subphrase depending on the method called.
ex: `aaroha(3)` would return 3 aaroha subphrases of length 3,6 and 7 respectively.
- `stutter`, as the name suggests, would stutter the note an integer number of times to make up the same note duration. 
- `degrade` takes a float value which is used to probabilistically skip notes while playing back. Higher the degrade value, more skips. `degrade=0` will play all notes. `degrade=1` will skip all.

cc @amoghpj 